### PR TITLE
Fix typo in module path in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 		"printj": "./bin/printj.njs"
 	},
 	"main": "./printj",
-	"module": "./print.mjs",
+	"module": "./printj.mjs",
 	"types": "types",
 	"browser": {
 		"process": false,


### PR DESCRIPTION
Otherwise tools like snowpack that rely on the module attribute fail.